### PR TITLE
feature/improving-ux-theme

### DIFF
--- a/template/Routes.tsx
+++ b/template/Routes.tsx
@@ -5,10 +5,7 @@ const { Navigator, Screen } = createStackNavigator();
 
 import { Home, Form } from 'src/screens';
 
-import { theme } from 'src/theme';
-
 const ScreenOptions = () => ({
-  cardStyle: { backgroundColor: theme.colors.secondary, paddingHorizontal: 16 },
   headerShown: false
 });
 

--- a/template/android/app/src/main/java/com/naverntstemplate/MainActivity.java
+++ b/template/android/app/src/main/java/com/naverntstemplate/MainActivity.java
@@ -1,13 +1,15 @@
 package com.naverntstemplate;
 
-import com.facebook.react.ReactActivity;
-import android.content.Intent;
 import android.content.res.Configuration;
+
+import androidx.annotation.NonNull;
+
+import com.facebook.react.ReactActivity;
 
 public class MainActivity extends ReactActivity {
 
   @Override
-  public void onConfigurationChanged(Configuration configuration) {
+  public void onConfigurationChanged(@NonNull Configuration configuration) {
     super.onConfigurationChanged(configuration);
     getReactInstanceManager()
       .onConfigurationChanged(this, configuration);

--- a/template/android/app/src/main/java/com/naverntstemplate/MainActivity.java
+++ b/template/android/app/src/main/java/com/naverntstemplate/MainActivity.java
@@ -1,8 +1,17 @@
 package com.naverntstemplate;
 
 import com.facebook.react.ReactActivity;
+import android.content.Intent;
+import android.content.res.Configuration;
 
 public class MainActivity extends ReactActivity {
+
+  @Override
+  public void onConfigurationChanged(Configuration configuration) {
+    super.onConfigurationChanged(configuration);
+    getReactInstanceManager()
+      .onConfigurationChanged(this, configuration);
+  }
 
   /**
    * Returns the name of the main component registered from JavaScript. This is used to schedule

--- a/template/package.json
+++ b/template/package.json
@@ -26,6 +26,7 @@
     "react": "17.0.1",
     "react-hook-form": "^7.6.4",
     "react-native": "0.64.0",
+    "react-native-android-navigation-bar": "^1.0.2",
     "react-native-config": "^1.4.2",
     "react-native-gesture-handler": "^1.10.3",
     "react-native-keyboard-aware-scroll-view": "^0.9.4",

--- a/template/src/app-module.tsx
+++ b/template/src/app-module.tsx
@@ -1,12 +1,11 @@
 import React, { FC } from 'react';
 import { StatusBar } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
-import { NavigationContainer, DefaultTheme, ExtendedTheme } from '@react-navigation/native';
-import { ThemeProvider } from 'styled-components/native';
+import { NavigationContainer, DefaultTheme, DarkTheme } from '@react-navigation/native';
 
-import { AppProviders } from 'src/context';
+import { AppProviders, ThemeProvider, ThemeConsumer, useTheme } from 'src/context';
 
-import { theme } from 'src/theme';
+import { light, dark } from 'src/theme';
 
 import Routes from '../Routes';
 
@@ -15,17 +14,18 @@ if (__DEV__) {
 }
 
 const App: FC = () => {
-  const MyTheme: ExtendedTheme = {
-    ...DefaultTheme,
-    colors: {
-      ...DefaultTheme.colors,
-      ...theme.colors
+  const {
+    theme: {
+      dark,
+      colors: { background }
     }
-  };
+  } = useTheme();
 
   return (
     <SafeAreaProvider>
-      <NavigationContainer theme={MyTheme}>
+      <NavigationContainer
+        theme={{ dark, colors: { ...(dark ? DarkTheme.colors : DefaultTheme.colors), background } }}
+      >
         <Routes />
       </NavigationContainer>
     </SafeAreaProvider>
@@ -33,13 +33,25 @@ const App: FC = () => {
 };
 
 export default (): JSX.Element => (
-  <ThemeProvider theme={theme}>
-    <AppProviders>
-      <StatusBar backgroundColor={theme.colors.secondary} barStyle='dark-content' />
+  <ThemeProvider watchSystemAppearence light={light} dark={dark}>
+    <ThemeConsumer>
+      {({
+        theme: {
+          dark,
+          colors: { background }
+        }
+      }) => (
+        <StatusBar
+          backgroundColor={background}
+          barStyle={dark ? 'light-content' : 'dark-content'}
+        />
+      )}
+    </ThemeConsumer>
 
+    <AppProviders>
       <App />
     </AppProviders>
   </ThemeProvider>
 );
 
-//export { default } from '../storybook';
+// export { default } from '../storybook';

--- a/template/src/components/Button/Button.tsx
+++ b/template/src/components/Button/Button.tsx
@@ -28,9 +28,7 @@ const Button: FC<ButtonComponent> = ({ text, variant, disabled, loading, ...prop
 
   const textColor = useMemo(() => {
     if (disabled) return colors.gray.n400;
-
-    if (variant === PRIMARY) return colors.secondary;
-
+    if (variant === PRIMARY) return colors.onPrimary;
     return colors.primary;
   }, [variant, disabled, colors]);
 

--- a/template/src/components/Button/Button.tsx
+++ b/template/src/components/Button/Button.tsx
@@ -1,8 +1,7 @@
 import React, { FC, useMemo } from 'react';
 import { TouchableOpacityProps, ActivityIndicator } from 'react-native';
 import { variant, space, layout } from 'styled-system';
-import styled from 'styled-components/native';
-import { useTheme } from '@react-navigation/native';
+import styled, { useTheme } from 'styled-components/native';
 
 import { ColumnProps, Text, Row } from 'src/components';
 

--- a/template/src/components/Input/Input.tsx
+++ b/template/src/components/Input/Input.tsx
@@ -1,8 +1,7 @@
 import React, { ForwardRefRenderFunction, useMemo, useState, forwardRef } from 'react';
 import { TextInputProps, Platform, TouchableOpacity } from 'react-native';
-import styled from 'styled-components/native';
+import styled, { useTheme } from 'styled-components/native';
 import Icon from 'react-native-vector-icons/FontAwesome';
-import { useTheme } from '@react-navigation/native';
 
 import { Column, ColumnProps, Text } from 'src/components';
 

--- a/template/src/components/Input/Input.tsx
+++ b/template/src/components/Input/Input.tsx
@@ -144,6 +144,7 @@ const StyledInput = styled.TextInput.attrs(({ theme: { colors }, multiline, ...r
   padding: 8px 10px;
   font-size: 16px;
   font-weight: 500;
+  color: ${({ theme }) => theme.colors.onBackground};
 `;
 
 export default forwardRef(InputComponent);

--- a/template/src/context/index.ts
+++ b/template/src/context/index.ts
@@ -1,2 +1,3 @@
 export { default as AppProviders } from './providers';
 export * from './user';
+export * from './theme';

--- a/template/src/context/theme.tsx
+++ b/template/src/context/theme.tsx
@@ -1,0 +1,104 @@
+import React, {
+  ReactNode,
+  FunctionComponent,
+  createContext,
+  useContext,
+  useState,
+  useMemo,
+  useEffect,
+  useCallback
+} from 'react';
+import { Appearance, ColorSchemeName } from 'react-native';
+import { ThemeProvider as StyledThemeProvider, DefaultTheme } from 'styled-components/native';
+import NavigationBar from 'react-native-android-navigation-bar';
+
+import { isSystemDarkModeSupported, unsupportedObservationWarning } from 'src/utils';
+
+type ThemeConsumable = (context: ThemeContextProps) => ReactNode;
+
+interface ThemeConsumerComponent {
+  (props: { children: ThemeConsumable }): JSX.Element;
+}
+
+interface ThemeContextProps {
+  theme: DefaultTheme;
+  deviceColorScheme: ColorSchemeName;
+  toggle: () => void;
+}
+
+interface BaseProps {
+  initialScheme?: ColorSchemeName;
+  children?: ReactNode;
+}
+
+interface WithSingleSchemeSupport extends BaseProps {
+  watchSystemAppearence?: boolean;
+  light?: DefaultTheme;
+  dark?: DefaultTheme;
+  base: DefaultTheme;
+}
+
+interface WithMultiSchemeSupport extends BaseProps {
+  watchSystemAppearence: boolean;
+  light: DefaultTheme;
+  dark: DefaultTheme;
+  base?: DefaultTheme;
+}
+
+const ThemeContext = createContext<ThemeContextProps>({} as ThemeContextProps);
+
+export const useTheme = (): ThemeContextProps => useContext(ThemeContext);
+
+export const ThemeConsumer: ThemeConsumerComponent = ({ children }) => (
+  <ThemeContext.Consumer>{context => children(context)}</ThemeContext.Consumer>
+);
+
+export const ThemeProvider: FunctionComponent<WithSingleSchemeSupport | WithMultiSchemeSupport> = ({
+  watchSystemAppearence,
+  initialScheme,
+  light,
+  dark,
+  base,
+  children
+}) => {
+  watchSystemAppearence &&
+    !isSystemDarkModeSupported &&
+    console.warn(unsupportedObservationWarning);
+
+  const [deviceColorScheme, setDeviceColorScheme] = useState(
+    () => initialScheme ?? Appearance.getColorScheme()
+  );
+
+  const theme = useMemo(() => {
+    if (!light && !dark) return base;
+    if (deviceColorScheme === 'light' && !!light) return light;
+    if (deviceColorScheme === 'dark' && !!dark) return dark;
+  }, [deviceColorScheme, light, dark, base]);
+
+  const toggle = useCallback(
+    () => dark && setDeviceColorScheme(state => (state === 'light' ? 'dark' : 'light')),
+    [dark]
+  );
+
+  const onAppearanceChanged = useCallback<Appearance.AppearanceListener>(
+    ({ colorScheme }) => setDeviceColorScheme(colorScheme),
+    []
+  );
+
+  useEffect(() => {
+    theme && NavigationBar.changeColor(theme.colors.background, !theme.dark, true);
+  }, [theme]);
+
+  useEffect(() => {
+    if (watchSystemAppearence && isSystemDarkModeSupported) {
+      Appearance.addChangeListener(onAppearanceChanged);
+      return () => Appearance.removeChangeListener(onAppearanceChanged);
+    }
+  }, [watchSystemAppearence, onAppearanceChanged]);
+
+  return (
+    <ThemeContext.Provider value={{ theme: theme!, deviceColorScheme, toggle }}>
+      <StyledThemeProvider theme={theme!}>{children}</StyledThemeProvider>
+    </ThemeContext.Provider>
+  );
+};

--- a/template/src/context/theme.tsx
+++ b/template/src/context/theme.tsx
@@ -12,7 +12,7 @@ import { Appearance, ColorSchemeName } from 'react-native';
 import { ThemeProvider as StyledThemeProvider, DefaultTheme } from 'styled-components/native';
 import NavigationBar from 'react-native-android-navigation-bar';
 
-import { isSystemDarkModeSupported, unsupportedObservationWarning } from 'src/utils';
+import { isSystemDarkModeSupported, unsupportedWatchSystemAppearanceWarning } from 'src/utils';
 
 type ThemeConsumable = (context: ThemeContextProps) => ReactNode;
 
@@ -63,7 +63,7 @@ export const ThemeProvider: FunctionComponent<WithSingleSchemeSupport | WithMult
 }) => {
   watchSystemAppearence &&
     !isSystemDarkModeSupported &&
-    console.warn(unsupportedObservationWarning);
+    console.warn(unsupportedWatchSystemAppearanceWarning);
 
   const [deviceColorScheme, setDeviceColorScheme] = useState(
     () => initialScheme ?? Appearance.getColorScheme()

--- a/template/src/index.d.ts
+++ b/template/src/index.d.ts
@@ -1,63 +1,36 @@
-import '@react-navigation/native';
+import 'styled-components/native';
 
-// Override the theme in react native navigation to accept our custom theme props.
-declare module '@react-navigation/native' {
-  export type ExtendedTheme = {
-    dark: boolean;
-    colors: {
-      primary: string;
-      secondary: string;
-      white: string;
-      black: string;
-      error: string;
-      warning: string;
-      success: string;
-      background: string;
-      card: string;
-      text: string;
-      border: string;
-      notification: string;
-      gray: {
-        n50: string;
-        n100: string;
-        n200: string;
-        n300: string;
-        n400: string;
-        n500: string;
-        n600: string;
-        n700: string;
-        n800: string;
-        n900: string;
-      };
+interface AppTheme {
+  dark: boolean;
+  colors: {
+    primary: string;
+    secondary: string;
+    white: string;
+    black: string;
+    error: string;
+    warning: string;
+    success: string;
+    background: string;
+    card: string;
+    text: string;
+    border: string;
+    notification: string;
+    gray: {
+      n50: string;
+      n100: string;
+      n200: string;
+      n300: string;
+      n400: string;
+      n500: string;
+      n600: string;
+      n700: string;
+      n800: string;
+      n900: string;
     };
   };
-  export function useTheme(): ExtendedTheme;
 }
 
-import 'styled-components';
-
 declare module 'styled-components' {
-  export interface DefaultTheme {
-    colors: {
-      white: string;
-      black: string;
-      error: string;
-      warning: string;
-      success: string;
-      primary: string;
-      secondary: string;
-      gray: {
-        n50: string;
-        n100: string;
-        n200: string;
-        n300: string;
-        n400: string;
-        n500: string;
-        n600: string;
-        n700: string;
-        n800: string;
-        n900: string;
-      };
-    };
-  }
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  export interface DefaultTheme extends AppTheme {}
 }

--- a/template/src/index.d.ts
+++ b/template/src/index.d.ts
@@ -5,15 +5,13 @@ interface AppTheme {
   colors: {
     primary: string;
     secondary: string;
-    white: string;
-    black: string;
+    background: string;
+    onPrimary: string;
+    onSecondary: string;
+    onBackground: string;
     error: string;
     warning: string;
     success: string;
-    background: string;
-    card: string;
-    text: string;
-    border: string;
     notification: string;
     gray: {
       n50: string;

--- a/template/src/screens/Form/Form.tsx
+++ b/template/src/screens/Form/Form.tsx
@@ -1,11 +1,11 @@
 import React, { FC, useRef, MutableRefObject, useState } from 'react';
 import { useForm, Controller } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
+import { useTheme } from 'styled-components/native';
 
 import { Column, Input, InputRef, Button, KeyboardAwareScrollView } from 'src/components';
 
 import { FormExampleSchema } from 'src/utils';
-import { padding } from 'styled-system';
 
 interface FormExampleData {
   email: string;
@@ -13,6 +13,9 @@ interface FormExampleData {
 }
 
 const Form: FC = () => {
+  const passwordInputRef = useRef() as MutableRefObject<InputRef>;
+  const { colors } = useTheme();
+
   const {
     control,
     handleSubmit,
@@ -26,7 +29,6 @@ const Form: FC = () => {
       password: ''
     }
   });
-  const passwordInputRef = useRef() as MutableRefObject<InputRef>;
 
   const [isPasswordInput, setIsPasswordInput] = useState(true);
 
@@ -40,7 +42,7 @@ const Form: FC = () => {
   };
 
   return (
-    <Column flex={1}>
+    <Column flex={1} bg={colors.background}>
       <KeyboardAwareScrollView
         contentContainerStyle={{
           flex: 1,

--- a/template/src/screens/Home/Home.tsx
+++ b/template/src/screens/Home/Home.tsx
@@ -1,24 +1,37 @@
 import React, { FC } from 'react';
-import { useTheme, useNavigation } from '@react-navigation/native';
+import { useNavigation } from '@react-navigation/native';
 import Icon from 'react-native-vector-icons/FontAwesome';
+
+import { useTheme } from 'src/context';
 
 import { Column, Row, Text, Button } from 'src/components';
 
 const Home: FC = () => {
-  const { colors } = useTheme();
+  const {
+    toggle,
+    theme: {
+      dark,
+      colors: { primary, background }
+    }
+  } = useTheme();
   const { navigate } = useNavigation();
 
   return (
-    <Column alignItems='center' flex={1} justifyContent='center' p='16px'>
+    <Column alignItems='center' flex={1} justifyContent='center' p='16px' bg={background}>
       <Row alignItems='center' mb='10px'>
-        <Text color={colors.primary} mr={2}>
+        <Text color={primary} mr={2}>
           Built with react-native-nave-typescript
         </Text>
 
-        <Icon name='rocket' size={24} color={colors.primary} />
+        <Icon name='rocket' size={24} color={primary} />
       </Row>
 
       <Button text='Form example' onPress={() => navigate('Form')} />
+      <Button
+        variant='secondary'
+        text={`Change to ${dark ? 'light' : 'dark'} theme`}
+        onPress={toggle}
+      />
     </Column>
   );
 };

--- a/template/src/theme/dark.ts
+++ b/template/src/theme/dark.ts
@@ -3,12 +3,12 @@ import { DefaultTheme } from 'styled-components/native';
 export default {
   dark: true,
   colors: {
-    primary: 'rgb(191, 90, 242)',
-    secondary: 'rgb(94, 92, 230)',
-    background: 'rgb(28, 28, 30)',
-    onPrimary: 'rgb(242, 242, 242)',
-    onSecondary: 'rgb(242, 242, 242)',
-    onBackground: 'rgb(242, 242, 242)',
+    primary: '#bf5af2',
+    secondary: '#5e5ce6',
+    background: '#1c1c1e',
+    onPrimary: '#f2f2f2',
+    onSecondary: '#f2f2f2',
+    onBackground: '#f2f2f2',
     error: '#D50000',
     warning: '#F49F14',
     success: '#43A047',

--- a/template/src/theme/dark.ts
+++ b/template/src/theme/dark.ts
@@ -3,14 +3,15 @@ import { DefaultTheme } from 'styled-components/native';
 export default {
   dark: true,
   colors: {
-    black: '#000000',
-    white: '#ffffff',
+    primary: 'rgb(191, 90, 242)',
+    secondary: 'rgb(94, 92, 230)',
+    background: 'rgb(28, 28, 30)',
+    onPrimary: 'rgb(242, 242, 242)',
+    onSecondary: 'rgb(242, 242, 242)',
+    onBackground: 'rgb(242, 242, 242)',
     error: '#D50000',
     warning: '#F49F14',
     success: '#43A047',
-    primary: '#6600CA',
-    secondary: '#ffffff',
-    background: '#161616',
     gray: {
       n50: '#FAFAFA',
       n100: '#F5F5F5',

--- a/template/src/theme/dark.ts
+++ b/template/src/theme/dark.ts
@@ -1,4 +1,7 @@
+import { DefaultTheme } from 'styled-components/native';
+
 export default {
+  dark: true,
   colors: {
     black: '#000000',
     white: '#ffffff',
@@ -7,6 +10,7 @@ export default {
     success: '#43A047',
     primary: '#6600CA',
     secondary: '#ffffff',
+    background: '#161616',
     gray: {
       n50: '#FAFAFA',
       n100: '#F5F5F5',
@@ -20,4 +24,4 @@ export default {
       n900: '#212121'
     }
   }
-};
+} as DefaultTheme;

--- a/template/src/theme/index.ts
+++ b/template/src/theme/index.ts
@@ -1,1 +1,2 @@
-export { default as theme } from './theme';
+export { default as light } from './light';
+export { default as dark } from './dark';

--- a/template/src/theme/light.ts
+++ b/template/src/theme/light.ts
@@ -3,14 +3,15 @@ import { DefaultTheme } from 'styled-components/native';
 export default {
   dark: false,
   colors: {
-    black: '#000000',
-    white: '#ffffff',
+    primary: 'rgb(175, 82, 222)',
+    secondary: 'rgb(94, 92, 230)',
+    background: 'rgb(242, 242, 242)',
+    onPrimary: 'rgb(242, 242, 242)',
+    onSecondary: 'rgb(242, 242, 242)',
+    onBackground: 'rgb(28, 28, 30)',
     error: '#D50000',
     warning: '#F49F14',
     success: '#43A047',
-    primary: '#6600CA',
-    secondary: '#ffffff',
-    background: '#ffffff',
     gray: {
       n50: '#FAFAFA',
       n100: '#F5F5F5',

--- a/template/src/theme/light.ts
+++ b/template/src/theme/light.ts
@@ -3,12 +3,12 @@ import { DefaultTheme } from 'styled-components/native';
 export default {
   dark: false,
   colors: {
-    primary: 'rgb(175, 82, 222)',
-    secondary: 'rgb(94, 92, 230)',
-    background: 'rgb(242, 242, 242)',
-    onPrimary: 'rgb(242, 242, 242)',
-    onSecondary: 'rgb(242, 242, 242)',
-    onBackground: 'rgb(28, 28, 30)',
+    primary: '#af52de',
+    secondary: '#5e5ce6',
+    background: '#f2f2f2',
+    onPrimary: '#f2f2f2',
+    onSecondary: '#f2f2f2',
+    onBackground: '#1c1c1e',
     error: '#D50000',
     warning: '#F49F14',
     success: '#43A047',

--- a/template/src/theme/light.ts
+++ b/template/src/theme/light.ts
@@ -1,0 +1,27 @@
+import { DefaultTheme } from 'styled-components/native';
+
+export default {
+  dark: false,
+  colors: {
+    black: '#000000',
+    white: '#ffffff',
+    error: '#D50000',
+    warning: '#F49F14',
+    success: '#43A047',
+    primary: '#6600CA',
+    secondary: '#ffffff',
+    background: '#ffffff',
+    gray: {
+      n50: '#FAFAFA',
+      n100: '#F5F5F5',
+      n200: '#EEEEEE',
+      n300: '#E0E0E0',
+      n400: '#BDBDBD',
+      n500: '#9E9E9E',
+      n600: '#757575',
+      n700: '#616161',
+      n800: '#424242',
+      n900: '#212121'
+    }
+  }
+} as DefaultTheme;

--- a/template/src/utils/index.ts
+++ b/template/src/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './auth';
 export * from './yup-schemas';
+export * from './system';

--- a/template/src/utils/system.ts
+++ b/template/src/utils/system.ts
@@ -1,0 +1,22 @@
+import { Platform } from 'react-native';
+
+const ANDROID_SUPPORTED_SINCE_SDK = 29;
+const IOS_SUPPORTED_SINCE_VERSION = 13;
+const UNSUPPORTED_OBSERVE_SYSTEM_WARNING =
+  'observeSystem wont work because Dark Mode is only supported on :platform_label greather than or equal :version';
+
+export const isSystemDarkModeSupported = Platform.select({
+  android: (Platform.Version as number) >= ANDROID_SUPPORTED_SINCE_SDK,
+  ios: (Platform.Version as number) >= IOS_SUPPORTED_SINCE_VERSION
+});
+
+export const unsupportedObservationWarning = Platform.select({
+  android: UNSUPPORTED_OBSERVE_SYSTEM_WARNING.replace(':platform_label', 'Android SDK').replace(
+    ':version',
+    ANDROID_SUPPORTED_SINCE_SDK.toString()
+  ),
+  ios: UNSUPPORTED_OBSERVE_SYSTEM_WARNING.replace(':platform_label', 'IOS').replace(
+    ':version',
+    IOS_SUPPORTED_SINCE_VERSION.toString()
+  )
+});

--- a/template/src/utils/system.ts
+++ b/template/src/utils/system.ts
@@ -2,20 +2,20 @@ import { Platform } from 'react-native';
 
 const ANDROID_SUPPORTED_SINCE_SDK = 29;
 const IOS_SUPPORTED_SINCE_VERSION = 13;
-const UNSUPPORTED_OBSERVE_SYSTEM_WARNING =
-  'observeSystem wont work because Dark Mode is only supported on :platform_label greather than or equal :version';
+const WATCH_SYSTEM_APPEARANCE_WARNING =
+  'watchSystemAppearence wont work because Dark Mode is only supported on :platform_label greather than or equal :version';
 
 export const isSystemDarkModeSupported = Platform.select({
   android: (Platform.Version as number) >= ANDROID_SUPPORTED_SINCE_SDK,
   ios: (Platform.Version as number) >= IOS_SUPPORTED_SINCE_VERSION
 });
 
-export const unsupportedObservationWarning = Platform.select({
-  android: UNSUPPORTED_OBSERVE_SYSTEM_WARNING.replace(':platform_label', 'Android SDK').replace(
+export const unsupportedWatchSystemAppearanceWarning = Platform.select({
+  android: WATCH_SYSTEM_APPEARANCE_WARNING.replace(':platform_label', 'Android SDK').replace(
     ':version',
     ANDROID_SUPPORTED_SINCE_SDK.toString()
   ),
-  ios: UNSUPPORTED_OBSERVE_SYSTEM_WARNING.replace(':platform_label', 'IOS').replace(
+  ios: WATCH_SYSTEM_APPEARANCE_WARNING.replace(':platform_label', 'IOS').replace(
     ':version',
     IOS_SUPPORTED_SINCE_VERSION.toString()
   )

--- a/template/storybook/decorator.js
+++ b/template/storybook/decorator.js
@@ -1,22 +1,14 @@
 import React from 'react';
-import { NavigationContainer, DefaultTheme } from '@react-navigation/native';
-import { ThemeProvider } from 'styled-components/native';
 
-import { theme } from 'src/theme';
+import { ThemeProvider } from 'src/context';
 
-const MyTheme = {
-  ...DefaultTheme,
-  colors: {
-    ...DefaultTheme.colors,
-    ...theme.colors
-  }
-};
+import { light, dark } from 'src/theme';
 
 const withThemeProvider = storyFn => {
   return (
-    <NavigationContainer theme={MyTheme}>
-      <ThemeProvider theme={theme}>{storyFn()}</ThemeProvider>
-    </NavigationContainer>
+    <ThemeProvider watchSystemAppearence light={light} dark={dark}>
+      {storyFn()}
+    </ThemeProvider>
   );
 };
 

--- a/template/yarn.lock
+++ b/template/yarn.lock
@@ -10575,6 +10575,11 @@ react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
+react-native-android-navigation-bar@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/react-native-android-navigation-bar/-/react-native-android-navigation-bar-1.0.2.tgz#fa658967eef0033a7625778a8337465bfb8fc6ca"
+  integrity sha512-cbKpAyqEThsqVlcSwtHMON3TdrAQkojMaykZxHIPr0bth9sp3dAazMJo/B/YTZqMNjcddp3zVdf1hednR/wKJQ==
+
 react-native-animatable@1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/react-native-animatable/-/react-native-animatable-1.3.3.tgz#a13a4af8258e3bb14d0a9d839917e9bb9274ec8a"


### PR DESCRIPTION
### O QUE FOI FEITO
- `ThemeProvider` customizável com possibilidade de observar eventuais mudanças no tema do dispositivo e replicar na aplicação

### COMO TESTAR
**Requisitos da funcionalidade**: Android SDK >= 29 ou IOS >= 13. Menor que isso, só é possível dar toggle no tema
- Instalar novas dependências com `yarn` ou `npm`
- Abrir a aplicação e verificar se o tema aplicado corresponde ao tema do dispositivo
- Com a aplicação em background, mudar o tema do dispositivo nas configurações e verificar se a mudança é refletida
- Para o Android, verificar se a mudança do tema também reflete na `NavigationBar` (barra inferior do sistema).
- Verificar se os componentes no Storyblok também refletem as alterações

### COISINHAS A+
- Testar dentro do `app-module.tsx` e dar feedback de como o IntelliSense reage as props passadas para o `ThemeProvider`, em termos de experiência de desenvolvimento
